### PR TITLE
Validate name of layer instances to only accept alphanumeric characters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,3 +83,13 @@ jobs:
           layerform list instances | tee instances
           # fails if instance is still there
           ! grep -E 'test_bar\s+bar\s+foo=default\s+alive' instances
+
+      - name: Can't spawn instance with invalid name
+        run: |
+          # fails if spawn succeeds
+          ! layerform spawn foo 'this has spaces'
+          ! layerform spawn foo 'this#has%special&chars'
+          ! layerform spawn foo '_cant-start-with-underscore'
+          ! layerform spawn foo '-cant-start-with-dash'
+          ! layerform spawn foo 'cant-end-with-underscore_'
+          ! layerform spawn foo 'cant-end-with-dash-'

--- a/cmd/cli/spawn.go
+++ b/cmd/cli/spawn.go
@@ -75,7 +75,7 @@ If an instance with the same ID already exists for the layer definition, Layerfo
 
 		if !alphanumericRegex.MatchString(instanceName) {
 			fmt.Fprintf(os.Stderr, "Invalid name: %s\n", instanceName)
-			fmt.Fprintln(os.Stderr, "Name must must start and end with an alphanumeric character and can include dashes and underscores in between.")
+			fmt.Fprintln(os.Stderr, "Name must start and end with an alphanumeric character and can include dashes and underscores in between.")
 			os.Exit(1)
 		}
 

--- a/cmd/cli/spawn.go
+++ b/cmd/cli/spawn.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/ergomake/layerform/internal/lfconfig"
 	"github.com/hashicorp/go-hclog"
 	"github.com/lithammer/shortuuid/v3"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/ergomake/layerform/internal/lfconfig"
 )
 
 func init() {


### PR DESCRIPTION
## Why this matters

<!-- In this section , add details of PR and what changes it brings . Try to explain why this PR matters -->

This PR validates name of layer instances to only accept alphanumeric characters.

## Solution

<!-- List all the proposed changes in your PR -->

<!-- Provide breif description of the approach you are using to resolve the issue -->

Add regexp `^[A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]$` to validate name of layer instances.

## How to test it

<!-- This field is optional -->

<!-- Provide the steps to test the changes are working as expected -->

I run it locally and add some e2e tests as mentioned in https://github.com/ergomake/layerform/issues/67#issuecomment-1712731234.

```
➜  layerform git:(67-validate-layer-name) ✗ go run . spawn foo 'this has spaces'
Invalid name: this has spaces
Name must must start and end with an alphanumeric character and can include dashes and underscores in between.
exit status 1
```

## Note to reviewers

<!-- Add notes to reviewers if applicable -->