### PR TITLE
Validate name of layer definitions to only accept alphanumeric characters

### DIFF
--- a/cmd/cli/configure.go
+++ b/cmd/cli/configure.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/ergomake/layerform/internal/layerfile"
 	"github.com/ergomake/layerform/internal/lfconfig"
 	"github.com/ergomake/layerform/pkg/command"
 )
@@ -93,6 +94,13 @@ Here's an example layer definition configurations:
 
 		err = configure.Run(ctx, fpath)
 		if err != nil {
+			if errors.Is(err, layerfile.ErrInvalidDefinitionName) {
+				fmt.Fprintln(
+					os.Stderr,
+					"Name must start and end with an alphanumeric character and can include dashes and underscores in between.",
+				)
+			}
+
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}

--- a/internal/layerfile/layerfile.go
+++ b/internal/layerfile/layerfile.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ergomake/layerform/pkg/data"
 )
 
+var ErrInvalidDefinitionName = errors.New("invalid layer definition name")
+
 var alphanumericRegex = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]$")
 
 type layerfile struct {
@@ -43,7 +45,7 @@ func (lf *layerfile) ToLayers() ([]*data.LayerDefinition, error) {
 	dataLayers := make([]*data.LayerDefinition, len(lf.Layers))
 	for i, l := range lf.Layers {
 		if !alphanumericRegex.MatchString(l.Name) {
-			return nil, errors.Errorf("invalid name: %s", l.Name)
+			return nil, errors.Wrap(ErrInvalidDefinitionName, l.Name)
 		}
 
 		files := []data.LayerDefinitionFile{}

--- a/internal/layerfile/layerfile.go
+++ b/internal/layerfile/layerfile.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 
 	"github.com/pkg/errors"
 
 	"github.com/ergomake/layerform/pkg/data"
 )
+
+var alphanumericRegex = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]$")
 
 type layerfile struct {
 	sourceFilepath string           `json:"-"`
@@ -39,6 +42,10 @@ func (lf *layerfile) ToLayers() ([]*data.LayerDefinition, error) {
 
 	dataLayers := make([]*data.LayerDefinition, len(lf.Layers))
 	for i, l := range lf.Layers {
+		if !alphanumericRegex.MatchString(l.Name) {
+			return nil, errors.Errorf("invalid name: %s", l.Name)
+		}
+
 		files := []data.LayerDefinitionFile{}
 		for _, f := range l.Files {
 			matches, err := filepath.Glob(path.Join(dir, f))

--- a/internal/layerfile/layerfile_test.go
+++ b/internal/layerfile/layerfile_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +83,56 @@ func TestToLayers(t *testing.T) {
 	assert.Equal(t, "main.tf", modelLayers[0].Files[0].Path)
 	assert.Equal(t, mainTfContent, modelLayers[0].Files[0].Content)
 	assert.Equal(t, 0, len(modelLayers[0].Dependencies))
+}
+
+func TestToLayers_ValidateNameOfLayerDefinitions(t *testing.T) {
+	tests := []struct {
+		name string
+		lf   layerfile
+		err  error
+	}{
+		{
+			name: "Name has spaces",
+			lf: layerfile{
+				Layers: []layerfileLayer{
+					{
+						Name: "invalid name for a layer definition",
+					},
+				},
+			},
+			err: errors.New("invalid name: invalid name for a layer definition"),
+		},
+		{
+			name: "Name has special character",
+			lf: layerfile{
+				Layers: []layerfileLayer{
+					{
+						Name: "invalid!",
+					},
+				},
+			},
+			err: errors.New("invalid name: invalid!"),
+		},
+		{
+			name: "Valid name",
+			lf: layerfile{
+				Layers: []layerfileLayer{
+					{
+						Name: "validname",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.lf.ToLayers()
+			if err != nil {
+				assert.EqualError(t, tt.err, err.Error())
+			} else {
+				assert.NoError(t, tt.err)
+			}
+		})
+	}
 }

--- a/internal/layerfile/layerfile_test.go
+++ b/internal/layerfile/layerfile_test.go
@@ -100,7 +100,7 @@ func TestToLayers_ValidateNameOfLayerDefinitions(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid name: invalid name for a layer definition"),
+			err: errors.Wrap(ErrInvalidDefinitionName, "invalid name for a layer definition"),
 		},
 		{
 			name: "Name has special character",
@@ -111,7 +111,7 @@ func TestToLayers_ValidateNameOfLayerDefinitions(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid name: invalid!"),
+			err: errors.Wrap(ErrInvalidDefinitionName, "invalid!"),
 		},
 		{
 			name: "Valid name",


### PR DESCRIPTION
## Why this matters

<!-- In this section , add details of PR and what changes it brings . Try to explain why this PR matters -->

This PR validates name of layer definitions to only accept alphanumeric characters.

## Solution

<!-- List all the proposed changes in your PR -->

<!-- Provide breif description of the approach you are using to resolve the issue -->

Add regexp `^[A-Za-z0-9][A-Za-z0-9_-]*[A-Za-z0-9]$` to validate name of layer definitions.

## How to test it

<!-- This field is optional -->

<!-- Provide the steps to test the changes are working as expected -->

Run `make test`.

Or to make it specific, you can do `go test -v -run=TestToLayers_ValidateNameOfLayerDefinitions github.com/ergomake/layerform/internal/layerfile`.

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

Issue: https://github.com/ergomake/layerform/issues/68