### PR TITLE
Refresh

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,13 @@ jobs:
           layerform output bar test_bar | jq .foo_file.value | tee output
           grep -E '\.layerform\/examples\/local\/foo-.{4}\/\.keep' output
 
+      - name: Refresh
+        run: |
+          layerform refresh bar test_bar --var prefix=test-prefix-
+          layerform output bar test_bar | jq .bar_file.value | tee output
+          grep -E '\.layerform\/examples\/local\/test-prefix-foo-.{4}\/bar-.{4}\.txt' output
+          layerform refresh bar test_bar
+
       - name: Can't kill instance that has dependants
         run: |
           # fails if kill succeeds

--- a/cmd/cli/configure.go
+++ b/cmd/cli/configure.go
@@ -51,8 +51,7 @@ Here's an example layer definition configurations:
       ]
     }
   ]
-}
-`,
+}`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		logger := hclog.Default()
 		logLevel := hclog.LevelFromString(os.Getenv("LF_LOG"))

--- a/cmd/cli/list.go
+++ b/cmd/cli/list.go
@@ -16,5 +16,8 @@ var listCmd = &cobra.Command{
 Prints a table of the most important information about the specified resource.`,
 
 	Example: `# List all layer definitions
-layerform list definitions`,
+layerform list definitions
+
+# List all layer instances
+layerform list instances`,
 }

--- a/cmd/cli/list_definitions.go
+++ b/cmd/cli/list_definitions.go
@@ -26,7 +26,6 @@ var listDefinitionsCmd = &cobra.Command{
 	Long: `List layers definitions.
 
 Prints a table of the most important information about layer definitions.`,
-
 	Run: func(_ *cobra.Command, _ []string) {
 		logger := hclog.Default()
 		logLevel := hclog.LevelFromString(os.Getenv("LF_LOG"))

--- a/cmd/cli/list_instances.go
+++ b/cmd/cli/list_instances.go
@@ -25,7 +25,6 @@ var listInstancesCmd = &cobra.Command{
 	Long: `List layers instances.
 
 Prints a table of the most important information about layer instances.`,
-
 	Run: func(_ *cobra.Command, _ []string) {
 		logger := hclog.Default()
 		logLevel := hclog.LevelFromString(os.Getenv("LF_LOG"))

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -14,8 +14,7 @@ var rootCmd = &cobra.Command{
 	Short: "Layerform helps engineers create their own staging environments using plain Terraform files.",
 	Long: `Layerform helps engineers create their own staging environments using plain Terraform files.
 
-Please read our documentation at https://docs.layerform.dev for more information.
-`,
+Please read our documentation at https://docs.layerform.dev for more information.`,
 }
 
 func SetVersionInfo(version, commit, date string) {

--- a/cmd/cli/spawn.go
+++ b/cmd/cli/spawn.go
@@ -29,8 +29,7 @@ var spawnCmd = &cobra.Command{
 
 Whenever a desired ID is not provided, Layerform will generate a random UUID for the layer instance.
 
-If an instance with the same ID already exists for the layer definition, Layerform will return an error.
-    `,
+If an instance with the same ID already exists for the layer definition, Layerform will return an error.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := hclog.Default()

--- a/examples/local/foo.tf
+++ b/examples/local/foo.tf
@@ -1,5 +1,10 @@
+variable "prefix" {
+  type    = string
+  default = ""
+}
+
 locals {
-  dir = pathexpand("~/.layerform/examples/local/foo-${random_string.foo_suffix.result}")
+  dir = pathexpand("~/.layerform/examples/local/${var.prefix}foo-${random_string.foo_suffix.result}")
 }
 
 resource "local_file" "foo" {

--- a/internal/lfconfig/config.go
+++ b/internal/lfconfig/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ergomake/layerform/internal/storage"
 	"github.com/ergomake/layerform/pkg/command/kill"
+	"github.com/ergomake/layerform/pkg/command/refresh"
 	"github.com/ergomake/layerform/pkg/command/spawn"
 	"github.com/ergomake/layerform/pkg/layerdefinitions"
 	"github.com/ergomake/layerform/pkg/layerinstances"
@@ -218,4 +219,34 @@ func (c *config) GetKillCommand(ctx context.Context) (kill.Kill, error) {
 	}
 
 	return nil, errors.Errorf("fail to get kill command unexpected context type %s", t)
+}
+
+func (c *config) GetRefreshCommand(ctx context.Context) (refresh.Refresh, error) {
+	t := c.getCurrent().Type
+
+	switch t {
+	case "ergomake":
+		// TODO: hardcode production ergomake url here
+		baseURL := os.Getenv("LF_ERGOMAKE_URL")
+		if baseURL == "" {
+			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
+		}
+
+		return refresh.NewErgomake(baseURL), nil
+	case "s3":
+	case "local":
+		layersBackend, err := c.GetDefinitionsBackend(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "fail to get layers backend")
+		}
+
+		instancesBackend, err := c.GetInstancesBackend(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "fail to get instance backend")
+		}
+
+		return refresh.NewLocal(layersBackend, instancesBackend), nil
+	}
+
+	return nil, errors.Errorf("fail to get spawn command unexpected context type %s", t)
 }

--- a/pkg/command/kill/ergomake.go
+++ b/pkg/command/kill/ergomake.go
@@ -78,7 +78,13 @@ func (e *ergomakeKillCommand) Run(
 		return errors.Wrap(err, "fail to get layer instance")
 	}
 
-	hasDependants, err := HasDependants(ctx, e.instancesBackend, e.definitionsBackend, definitionName, instanceName)
+	hasDependants, err := HasDependants(
+		ctx,
+		e.instancesBackend,
+		e.definitionsBackend,
+		definitionName,
+		instanceName,
+	)
 	if err != nil {
 		s.Error()
 		sm.Stop()

--- a/pkg/command/kill/local.go
+++ b/pkg/command/kill/local.go
@@ -76,7 +76,13 @@ func (c *localKillCommand) Run(
 		),
 	)
 
-	hasDependants, err := HasDependants(ctx, c.instancesBackend, c.definitionsBackend, layerName, instanceName)
+	hasDependants, err := HasDependants(
+		ctx,
+		c.instancesBackend,
+		c.definitionsBackend,
+		layerName,
+		instanceName,
+	)
 	if err != nil {
 		s.Error()
 		sm.Stop()

--- a/pkg/command/refresh/ergomake.go
+++ b/pkg/command/refresh/ergomake.go
@@ -1,24 +1,37 @@
 package refresh
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/chelnak/ysmrr"
+	"github.com/chelnak/ysmrr/pkg/animations"
+	"github.com/chelnak/ysmrr/pkg/colors"
+	"github.com/hashicorp/go-hclog"
 	"github.com/pkg/errors"
 
+	"github.com/ergomake/layerform/pkg/data"
+	"github.com/ergomake/layerform/pkg/layerdefinitions"
 	"github.com/ergomake/layerform/pkg/layerinstances"
 )
 
 type ergomakeRefreshCommand struct {
-	baseURL          string
-	instancesBackend layerinstances.Backend
+	baseURL            string
+	instancesBackend   layerinstances.Backend
+	definitionsBackend layerdefinitions.Backend
 }
 
 var _ Refresh = &ergomakeRefreshCommand{}
 
 func NewErgomake(baseURL string) *ergomakeRefreshCommand {
 	instancesBackend := layerinstances.NewErgomake(baseURL)
+	definitionsBackend := layerdefinitions.NewErgomake(baseURL)
 
-	return &ergomakeRefreshCommand{baseURL, instancesBackend}
+	return &ergomakeRefreshCommand{baseURL, instancesBackend, definitionsBackend}
 }
 
 func (e *ergomakeRefreshCommand) Run(
@@ -26,5 +39,108 @@ func (e *ergomakeRefreshCommand) Run(
 	definitionName, instanceName string,
 	vars []string,
 ) error {
-	return errors.New("not implemented yet")
+	logger := hclog.FromContext(ctx)
+	logger.Debug("Refreshing instance remotely")
+
+	sm := ysmrr.NewSpinnerManager(
+		ysmrr.WithAnimation(animations.Dots),
+		ysmrr.WithSpinnerColor(colors.FgHiBlue),
+	)
+	sm.Start()
+	s := sm.AddSpinner(
+		fmt.Sprintf(
+			"Preparing to refresh instance \"%s\" of layer \"%s\"",
+			instanceName,
+			definitionName,
+		),
+	)
+
+	definition, err := e.definitionsBackend.GetLayer(ctx, definitionName)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to get layer definition")
+	}
+
+	_, err = e.instancesBackend.GetInstance(ctx, definition.Name, instanceName)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+
+		if errors.Is(err, layerinstances.ErrInstanceNotFound) {
+			return errors.Errorf(
+				"instance %s not found for layer %s",
+				instanceName,
+				definition.Name,
+			)
+		}
+
+		return errors.Wrap(err, "fail to get layer instance")
+	}
+
+	s.Complete()
+	s = sm.AddSpinner(fmt.Sprintf("Refreshing instance \"%s\" of layer \"%s\" remotely", instanceName, definitionName))
+
+	url := fmt.Sprintf("%s/v1/definitions/%s/instances/%s/refresh", e.baseURL, definitionName, instanceName)
+	dataBytes, err := json.Marshal(
+		map[string]interface{}{
+			"vars": vars,
+		},
+	)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to marshal instance to json")
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(dataBytes))
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to create http request to ergomake backend")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		s.Error()
+		sm.Stop()
+		return errors.Errorf("HTTP request to %s failed with status code %d", url, resp.StatusCode)
+	}
+
+	time.Sleep(time.Second * 2)
+	for {
+		instance, err := e.instancesBackend.GetInstance(ctx, definitionName, instanceName)
+		if err != nil {
+			s.Error()
+			sm.Stop()
+			return errors.Wrap(err, "fail to get instance to check spawning status")
+		}
+
+		switch instance.Status {
+		case data.LayerInstanceStatusRefreshing:
+			time.Sleep(time.Second * 2)
+			continue
+		case data.LayerInstanceStatusFaulty:
+			s.Error()
+			sm.Stop()
+			return errors.Errorf("fail to spawn instance %s of definition %s", instanceName, definitionName)
+		case data.LayerInstanceStatusAlive:
+			s.Complete()
+			sm.Stop()
+			return nil
+		default:
+			s.Error()
+			sm.Stop()
+			return errors.Errorf("instance entered a unexpected status of %s", string(instance.Status))
+		}
+	}
 }

--- a/pkg/command/refresh/ergomake.go
+++ b/pkg/command/refresh/ergomake.go
@@ -1,0 +1,30 @@
+package refresh
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/ergomake/layerform/pkg/layerinstances"
+)
+
+type ergomakeRefreshCommand struct {
+	baseURL          string
+	instancesBackend layerinstances.Backend
+}
+
+var _ Refresh = &ergomakeRefreshCommand{}
+
+func NewErgomake(baseURL string) *ergomakeRefreshCommand {
+	instancesBackend := layerinstances.NewErgomake(baseURL)
+
+	return &ergomakeRefreshCommand{baseURL, instancesBackend}
+}
+
+func (e *ergomakeRefreshCommand) Run(
+	ctx context.Context,
+	definitionName, instanceName string,
+	vars []string,
+) error {
+	return errors.New("not implemented yet")
+}

--- a/pkg/command/refresh/local.go
+++ b/pkg/command/refresh/local.go
@@ -1,0 +1,219 @@
+package refresh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/chelnak/ysmrr"
+	"github.com/chelnak/ysmrr/pkg/animations"
+	"github.com/chelnak/ysmrr/pkg/colors"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/pkg/errors"
+
+	"github.com/ergomake/layerform/internal/terraform"
+	"github.com/ergomake/layerform/internal/tfclient"
+	"github.com/ergomake/layerform/pkg/command"
+	"github.com/ergomake/layerform/pkg/data"
+	"github.com/ergomake/layerform/pkg/layerdefinitions"
+	"github.com/ergomake/layerform/pkg/layerinstances"
+)
+
+type localRefreshCommand struct {
+	definitionsBackend layerdefinitions.Backend
+	instancesBackend   layerinstances.Backend
+}
+
+var _ Refresh = &localRefreshCommand{}
+
+func NewLocal(
+	definitionsBackend layerdefinitions.Backend,
+	instancesBackend layerinstances.Backend,
+) *localRefreshCommand {
+	return &localRefreshCommand{definitionsBackend, instancesBackend}
+}
+
+func (c *localRefreshCommand) Run(
+	ctx context.Context,
+	definitionName, instanceName string,
+	vars []string,
+) error {
+	logger := hclog.FromContext(ctx)
+
+	sm := ysmrr.NewSpinnerManager(
+		ysmrr.WithAnimation(animations.Dots),
+		ysmrr.WithSpinnerColor(colors.FgHiBlue),
+	)
+	sm.Start()
+	s := sm.AddSpinner(
+		fmt.Sprintf(
+			"Preparing to refresh instance \"%s\" of layer \"%s\"",
+			instanceName,
+			definitionName,
+		),
+	)
+
+	definition, err := c.definitionsBackend.GetLayer(ctx, definitionName)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to get layer definition")
+	}
+
+	instance, err := c.instancesBackend.GetInstance(ctx, definition.Name, instanceName)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+
+		if errors.Is(err, layerinstances.ErrInstanceNotFound) {
+			return errors.Errorf(
+				"instance %s not found for layer %s",
+				instanceName,
+				definition.Name,
+			)
+		}
+
+		return errors.Wrap(err, "fail to get layer instance")
+	}
+
+	tfpath, err := terraform.GetTFPath(ctx)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to get terraform path")
+	}
+	logger.Debug("Using terraform from", "tfpath", tfpath)
+	logger.Debug("Found terraform installation", "tfpath", tfpath)
+
+	logger.Debug("Creating a temporary work directory")
+	workdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to create work directory")
+	}
+	defer os.RemoveAll(workdir)
+
+	layerDir := path.Join(workdir, definitionName)
+
+	instanceByLayer, err := command.ComputeInstanceByLayer(
+		ctx,
+		c.definitionsBackend,
+		c.instancesBackend,
+		definition,
+		instance,
+	)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to compute instance by layer instance")
+	}
+
+	layerWorkdir, err := command.WriteLayerToWorkdir(ctx, c.definitionsBackend, layerDir, definition, instanceByLayer)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to write layer to work directory")
+	}
+
+	statePath := path.Join(layerWorkdir, "terraform.tfstate")
+	err = os.WriteFile(statePath, instance.Bytes, 0644)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to write terraform state to work directory")
+	}
+
+	tf, err := tfclient.New(layerWorkdir, tfpath)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to get terraform client")
+	}
+
+	err = tf.Init(ctx, definition.SHA)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to terraform init")
+	}
+
+	logger.Debug("Looking for variable definitions in .tfvars files")
+	varFiles, err := command.FindTFVarFiles()
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to find .tfvars files")
+	}
+	logger.Debug(fmt.Sprintf("Found %d var files", len(varFiles)), "varFiles", varFiles)
+
+	applyOptions := []tfexec.ApplyOption{}
+	for _, vf := range varFiles {
+		applyOptions = append(applyOptions, tfexec.VarFile(vf))
+	}
+	for _, v := range vars {
+		applyOptions = append(applyOptions, tfexec.Var(v))
+	}
+
+	s.Complete()
+
+	s = sm.AddSpinner(
+		fmt.Sprintf(
+			"Refreshing instance \"%s\" of layer \"%s\"",
+			instanceName,
+			definitionName,
+		),
+	)
+
+	err = tf.Apply(ctx, applyOptions...)
+	if err != nil {
+		originalErr := err
+
+		nextStateBytes, err := os.ReadFile(statePath)
+		if err != nil {
+			s.Error()
+			sm.Stop()
+			return errors.Wrap(err, "fail to read next state")
+		}
+
+		// if this refresh attempt generated state, we should save it as faulty
+		// so user can fix it later
+		if len(nextStateBytes) > 0 {
+			instance.Bytes = nextStateBytes
+			instance.Status = data.LayerInstanceStatusFaulty
+			err = c.instancesBackend.SaveInstance(ctx, instance)
+			if err != nil {
+				s.Error()
+				sm.Stop()
+				return errors.Wrap(err, "fail to save instance of failed instance")
+			}
+		}
+
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(originalErr, "fail to terraform apply")
+	}
+
+	nextStateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to read next state")
+	}
+
+	instance.Bytes = nextStateBytes
+	instance.Status = data.LayerInstanceStatusAlive
+	err = c.instancesBackend.SaveInstance(ctx, instance)
+	if err != nil {
+		s.Error()
+		sm.Stop()
+		return errors.Wrap(err, "fail to save instance")
+	}
+
+	s.Complete()
+	sm.Stop()
+
+	return nil
+}

--- a/pkg/command/refresh/refresh.go
+++ b/pkg/command/refresh/refresh.go
@@ -1,0 +1,13 @@
+package refresh
+
+import (
+	"context"
+)
+
+type Refresh interface {
+	Run(
+		ctx context.Context,
+		definitionName, instanceName string,
+		vars []string,
+	) error
+}

--- a/pkg/data/instance.go
+++ b/pkg/data/instance.go
@@ -9,10 +9,11 @@ import (
 type LayerInstanceStatus string
 
 const (
-	LayerInstanceStatusSpawning LayerInstanceStatus = LayerInstanceStatus("spawning")
-	LayerInstanceStatusAlive    LayerInstanceStatus = LayerInstanceStatus("alive")
-	LayerInstanceStatusFaulty   LayerInstanceStatus = LayerInstanceStatus("faulty")
-	LayerInstanceStatusKilling  LayerInstanceStatus = LayerInstanceStatus("killing")
+	LayerInstanceStatusSpawning   LayerInstanceStatus = LayerInstanceStatus("spawning")
+	LayerInstanceStatusAlive      LayerInstanceStatus = LayerInstanceStatus("alive")
+	LayerInstanceStatusFaulty     LayerInstanceStatus = LayerInstanceStatus("faulty")
+	LayerInstanceStatusKilling    LayerInstanceStatus = LayerInstanceStatus("killing")
+	LayerInstanceStatusRefreshing LayerInstanceStatus = LayerInstanceStatus("refreshing")
 )
 
 const DEFAULT_LAYER_INSTANCE_NAME = "default"


### PR DESCRIPTION
## Why this matters

Adds the ability to update a layer instance after updating a definition instead of spawning a new thing. Also allows for changing variables of running instances.

## Solution

Introduce a new command: "refresh"

## How to test it

```console
$ layerform configure --file examples/local/layerform.json
✓ 3 layers loaded from "examples/local/layerform.json"
✓ Validating layer baz
✓ Validating layer foo
✓ Validating layer bar
✓ 3 layers saved to "/Users/lucas/.layerform/contexts/test-local/layerform.definitions.json"

$ layerform spawn bar test
✓ Preparing instance "test" of layer "bar"
✓ Preparing instance "default" of layer "foo"
✓ Spawning instance "default" of layer "foo"
✓ Spawning instance "test" of layer "bar"

$ layerform output bar test
{
  "bar_file": {
    "sensitive": false,
    "type": "string",
    "value": "/Users/lucas/.layerform/examples/local/foo-86aq/bar-tkbt.txt"
  },
  "foo_file": {
    "sensitive": false,
    "type": "string",
    "value": "/Users/lucas/.layerform/examples/local/foo-86aq/.keep"
  }
}

$ layerform refresh bar test --var "prefix=cool-prefix-"
✓ Preparing to refresh instance "test" of layer "bar"
✓ Refreshing instance "test" of layer "bar"

$ layerform output bar test                             
{
  "bar_file": {
    "sensitive": false,
    "type": "string",
    "value": "/Users/lucas/.layerform/examples/local/cool-prefix-foo-86aq/bar-tkbt.txt"
  },
  "foo_file": {
    "sensitive": false,
    "type": "string",
    "value": "/Users/lucas/.layerform/examples/local/cool-prefix-foo-86aq/.keep"
  }
}
```

## Note to reviewers

Closes #43 