### PR TITLE
introduce config set-context command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,14 +27,24 @@ jobs:
 
       - run: go install .
 
-      - name: Create Layerform config file
+      - name: layerform config set-context
         run: |
-          mkdir -p ~/.layerform
-          echo "currentContext: test" > ~/.layerform/config
-          echo "contexts:" >> ~/.layerform/config
-          echo "  test:" >> ~/.layerform/config
-          echo "    type: local" >> ~/.layerform/config
-          echo "    dir: test" >> ~/.layerform/config
+          # validations, fails if command succeeds
+          ! layerform config set-context test -t local # missing --dir
+
+          ! layerform config set-context test -t s3 --bucket bucket # missing region
+          ! layerform config set-context test -t s3 --region region # missing bucket
+
+          ! layerform config set-context test -t cloud --url "invalid url" --email e@mail.com --password strongpass
+          ! layerform config set-context test -t cloud --url https://a.b.com --email invalid --password strongpass
+          ! layerform config set-context test -t cloud --email invalid --password strongpass # missing url
+          ! layerform config set-context test -t cloud --url https://a.b.com --password strongpass # missing email
+          ! layerform config set-context test -t cloud --url https://a.b.com --email e@mail.com # missing password
+
+          # set valid contexts
+          layerform config set-context test-s3 -t s3 --bucket bucket --region us-east-1
+          layerform config set-context test-cloud -t cloud --url https://demo.layerform.dev --email foo@bar.com --password strongpass
+          layerform config set-context test-local -t local --dir test
 
       - name: Configure
         run: |

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Modify layerform config file",
+	Long:  `Modify layerform config file using subcomands like "layerform config set-context"`,
+	Example: `# Set a context entry in config
+layerform config set-context example --type=local --dir=~/.layerform/contexts/example`,
+}

--- a/cmd/cli/set_context.go
+++ b/cmd/cli/set_context.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/ergomake/layerform/internal/lfconfig"
+)
+
+func init() {
+	configSetContextCmd.Flags().StringP("type", "t", "local", "type of the context entry, must be \"local\", \"s3\" or \"cloud\"")
+	configSetContextCmd.Flags().String("dir", "", "directory to store definitions and instances, required when type is \"local\"")
+	configSetContextCmd.Flags().String("bucket", "", "bucket to store definitions and instances, required when type is \"s3\"")
+	configSetContextCmd.Flags().String("region", "", "region where bucket is located, required when type is \"s3\"")
+	configSetContextCmd.Flags().String("url", "", "url of layerform cloud, required when type is \"cloud\"")
+	configSetContextCmd.Flags().String("email", "", "email of layerform cloud user, required when type is \"cloud\"")
+	configSetContextCmd.Flags().String("password", "", "password of layerform cloud user, required when type is \"cloud\"")
+	configSetContextCmd.Flags().SortFlags = false
+
+	configCmd.AddCommand(configSetContextCmd)
+}
+
+var configSetContextCmd = &cobra.Command{
+	Use:   "set-context <name>",
+	Short: "Set a context entry in layerform config file",
+	Long:  "Set a context entry in layerform config file.",
+	Example: `# Set a context of type local named local-example
+layerform config set-context local-example -t local --dir example-dir
+
+# Set a context of type s3 named s3-example
+layerform config set-context s3-example -t s3 --bucket example-bucket --region us-east-1
+
+# Set a context of type cloud named cloud-example
+layerform config set-context cloud-example -t cloud --url https://example.layerform.dev --email foo@example.com --password secretpass`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+
+		t, _ := cmd.Flags().GetString("type")
+		configCtx := lfconfig.ConfigContext{Type: t}
+		switch configCtx.Type {
+		case "local":
+			dir, _ := cmd.Flags().GetString("dir")
+			configCtx.Type = t
+			configCtx.Dir = strings.TrimSpace(dir)
+		case "s3":
+			bucket, _ := cmd.Flags().GetString("bucket")
+			region, _ := cmd.Flags().GetString("region")
+			configCtx.Bucket = strings.TrimSpace(bucket)
+			configCtx.Region = strings.TrimSpace(region)
+		case "cloud":
+			url, _ := cmd.Flags().GetString("url")
+			email, _ := cmd.Flags().GetString("email")
+			password, _ := cmd.Flags().GetString("password")
+			configCtx.URL = strings.TrimSpace(url)
+			configCtx.Email = strings.TrimSpace(email)
+			configCtx.Password = strings.TrimSpace(password)
+		default:
+			fmt.Fprintf(os.Stderr, "invalid type %s\n", configCtx.Type)
+			os.Exit(1)
+		}
+
+		err := lfconfig.Validate(configCtx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "invalid context configuration"))
+			os.Exit(1)
+		}
+
+		cfg, err := lfconfig.Load("")
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to open config file"))
+			os.Exit(1)
+		}
+
+		action := "modified"
+		if cfg == nil {
+			action = "created"
+			cfg, err = lfconfig.Init(name, configCtx, "")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to initialize empty config"))
+				os.Exit(1)
+			}
+		} else {
+			prev, ok := cfg.Contexts[name]
+			if !ok {
+				action = "created"
+			}
+
+			if ok && prev.Type != t {
+				fmt.Fprintf(
+					os.Stderr,
+					"%s context already exists with a different type of %s, context type can't be updated.\n",
+					name,
+					cfg.GetCurrent().Type,
+				)
+				os.Exit(1)
+			}
+			cfg.Contexts[name] = configCtx
+		}
+
+		cfg.CurrentContext = name
+
+		err = cfg.Save()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to save config file"))
+			os.Exit(1)
+		}
+
+		fmt.Fprintf(os.Stdout, "Context \"%s\" %s.\n", name, action)
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}

--- a/cmd/cli/set_context.go
+++ b/cmd/cli/set_context.go
@@ -27,7 +27,9 @@ func init() {
 var configSetContextCmd = &cobra.Command{
 	Use:   "set-context <name>",
 	Short: "Set a context entry in layerform config file",
-	Long:  "Set a context entry in layerform config file.",
+	Long: `Set a context entry in layerform config file.
+
+  Specifying a name that already exists will update that context values unless the type is different.`,
 	Example: `# Set a context of type local named local-example
 layerform config set-context local-example -t local --dir example-dir
 
@@ -113,5 +115,4 @@ layerform config set-context cloud-example -t cloud --url https://example.layerf
 		fmt.Fprintf(os.Stdout, "Context \"%s\" %s.\n", name, action)
 	},
 	SilenceErrors: true,
-	SilenceUsage:  true,
 }

--- a/internal/lfconfig/config.go
+++ b/internal/lfconfig/config.go
@@ -154,14 +154,8 @@ func (c *config) GetInstancesBackend(ctx context.Context) (layerinstances.Backen
 	switch current.Type {
 	case "local":
 		blob = storage.NewFileStorage(path.Join(c.getDir(), stateFileName))
-	case "ergomake":
-		// TODO: hardcode production ergomake url here
-		baseURL := os.Getenv("LF_ERGOMAKE_URL")
-		if baseURL == "" {
-			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
-		}
-
-		return layerinstances.NewErgomake(baseURL), nil
+	case "cloud":
+		return layerinstances.NewCloud(current.URL), nil
 	case "s3":
 		b, err := storage.NewS3Backend(current.Bucket, stateFileName, current.Region)
 		if err != nil {
@@ -179,14 +173,8 @@ func (c *config) GetDefinitionsBackend(ctx context.Context) (layerdefinitions.Ba
 	current := c.GetCurrent()
 	var blob storage.FileLike
 	switch current.Type {
-	case "ergomake":
-		// TODO: hardcode production ergomake url here
-		baseURL := os.Getenv("LF_ERGOMAKE_URL")
-		if baseURL == "" {
-			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
-		}
-
-		return layerdefinitions.NewErgomake(baseURL), nil
+	case "cloud":
+		return layerdefinitions.NewCloud(current.URL), nil
 	case "local":
 		blob = storage.NewFileStorage(path.Join(c.getDir(), definitionsFileName))
 	case "s3":
@@ -201,17 +189,11 @@ func (c *config) GetDefinitionsBackend(ctx context.Context) (layerdefinitions.Ba
 }
 
 func (c *config) GetSpawnCommand(ctx context.Context) (spawn.Spawn, error) {
-	t := c.GetCurrent().Type
+	current := c.GetCurrent()
 
-	switch t {
-	case "ergomake":
-		// TODO: hardcode production ergomake url here
-		baseURL := os.Getenv("LF_ERGOMAKE_URL")
-		if baseURL == "" {
-			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
-		}
-
-		return spawn.NewErgomake(baseURL), nil
+	switch current.Type {
+	case "cloud":
+		return spawn.NewCloud(current.URL), nil
 	case "s3":
 		fallthrough
 	case "local":
@@ -228,21 +210,15 @@ func (c *config) GetSpawnCommand(ctx context.Context) (spawn.Spawn, error) {
 		return spawn.NewLocal(layersBackend, instancesBackend), nil
 	}
 
-	return nil, errors.Errorf("fail to get spawn command unexpected context type %s", t)
+	return nil, errors.Errorf("fail to get spawn command unexpected context type %s", current.Type)
 }
 
 func (c *config) GetKillCommand(ctx context.Context) (kill.Kill, error) {
-	t := c.GetCurrent().Type
+	current := c.GetCurrent()
 
-	switch t {
-	case "ergomake":
-		// TODO: hardcode production ergomake url here
-		baseURL := os.Getenv("LF_ERGOMAKE_URL")
-		if baseURL == "" {
-			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
-		}
-
-		return kill.NewErgomake(baseURL), nil
+	switch current.Type {
+	case "cloud":
+		return kill.NewCloud(current.URL), nil
 	case "s3":
 		fallthrough
 	case "local":
@@ -259,21 +235,15 @@ func (c *config) GetKillCommand(ctx context.Context) (kill.Kill, error) {
 		return kill.NewLocal(layersBackend, instancesBackend), nil
 	}
 
-	return nil, errors.Errorf("fail to get kill command unexpected context type %s", t)
+	return nil, errors.Errorf("fail to get kill command unexpected context type %s", current.Type)
 }
 
 func (c *config) GetRefreshCommand(ctx context.Context) (refresh.Refresh, error) {
-	t := c.GetCurrent().Type
+	current := c.GetCurrent()
 
-	switch t {
-	case "ergomake":
-		// TODO: hardcode production ergomake url here
-		baseURL := os.Getenv("LF_ERGOMAKE_URL")
-		if baseURL == "" {
-			return nil, errors.New("attempt to use ergomake backend but no LF_ERGOMAKE_URL in env")
-		}
-
-		return refresh.NewErgomake(baseURL), nil
+	switch current.Type {
+	case "cloud":
+		return refresh.NewCloud(current.URL), nil
 	case "s3":
 		fallthrough
 	case "local":
@@ -290,5 +260,5 @@ func (c *config) GetRefreshCommand(ctx context.Context) (refresh.Refresh, error)
 		return refresh.NewLocal(layersBackend, instancesBackend), nil
 	}
 
-	return nil, errors.Errorf("fail to get spawn command unexpected context type %s", t)
+	return nil, errors.Errorf("fail to get spawn command unexpected context type %s", current.Type)
 }

--- a/internal/lfconfig/config_test.go
+++ b/internal/lfconfig/config_test.go
@@ -52,6 +52,6 @@ contexts:
 		require.NoError(t, err)
 
 		assert.Equal(t, "context", cfg.CurrentContext)
-		assert.Equal(t, map[string]configContext{"context": {Type: "local", Dir: "test-dir"}}, cfg.Contexts)
+		assert.Equal(t, map[string]ConfigContext{"context": {Type: "local", Dir: "test-dir"}}, cfg.Contexts)
 	})
 }

--- a/internal/lfconfig/validate.go
+++ b/internal/lfconfig/validate.go
@@ -1,0 +1,78 @@
+package lfconfig
+
+import (
+	"net/url"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+func Validate(ctx ConfigContext) error {
+	var result *multierror.Error
+
+	switch ctx.Type {
+	case "local":
+		if ctx.Dir == "" {
+			result = multierror.Append(result, errors.New("directory path cannot be empty"))
+		} else if !isValidDirectory(ctx.Dir) {
+			result = multierror.Append(result, errors.Errorf("invalid directory path: %s", ctx.Dir))
+		}
+	case "s3":
+		if ctx.Bucket == "" {
+			result = multierror.Append(result, errors.New("S3 bucket name cannot be empty"))
+		} else if !isValidS3Bucket(ctx.Bucket) {
+			result = multierror.Append(result, errors.Errorf("invalid S3 bucket name: %s", ctx.Bucket))
+		}
+
+		if ctx.Region == "" {
+			result = multierror.Append(result, errors.New("S3 bucket region cannot be empty"))
+		} else if !isValidS3Region(ctx.Region) {
+			result = multierror.Append(result, errors.Errorf("invalid S3 bucket region: %s", ctx.Region))
+		}
+	case "cloud":
+		if ctx.Email == "" {
+			result = multierror.Append(result, errors.New("email cannot be empty"))
+		} else if !isValidEmail(ctx.Email) {
+			result = multierror.Append(result, errors.Errorf("invalid email: %s", ctx.Email))
+		}
+		if ctx.Password == "" {
+			result = multierror.Append(result, errors.New("password cannot be empty"))
+		}
+		if ctx.URL == "" {
+			result = multierror.Append(result, errors.New("URL cannot be empty"))
+		} else if !isValidURL(ctx.URL) {
+			result = multierror.Append(result, errors.Errorf("invalid URL: %s", ctx.URL))
+		}
+	default:
+		return errors.New("invalid context type")
+	}
+
+	return result.ErrorOrNil()
+}
+
+func isValidDirectory(path string) bool {
+	// TODO: validation of directory path
+	return true
+}
+
+func isValidS3Bucket(bucketName string) bool {
+	// TODO: validation of s3 bucket name
+	return true
+}
+
+func isValidS3Region(region string) bool {
+	// TODO: validation of s3 bucket region
+	return true
+}
+
+func isValidEmail(email string) bool {
+	pattern := "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+	match, _ := regexp.MatchString(pattern, email)
+	return match
+}
+
+func isValidURL(u string) bool {
+	_, err := url.Parse(u)
+	return err == nil
+}

--- a/pkg/command/kill/cloud.go
+++ b/pkg/command/kill/cloud.go
@@ -19,22 +19,22 @@ import (
 	"github.com/ergomake/layerform/pkg/layerinstances"
 )
 
-type ergomakeKillCommand struct {
+type cloudKillCommand struct {
 	baseURL            string
 	definitionsBackend layerdefinitions.Backend
 	instancesBackend   layerinstances.Backend
 }
 
-var _ Kill = &ergomakeKillCommand{}
+var _ Kill = &cloudKillCommand{}
 
-func NewErgomake(baseURL string) *ergomakeKillCommand {
-	definitionsBackend := layerdefinitions.NewErgomake(baseURL)
-	instancesBackend := layerinstances.NewErgomake(baseURL)
+func NewCloud(baseURL string) *cloudKillCommand {
+	definitionsBackend := layerdefinitions.NewCloud(baseURL)
+	instancesBackend := layerinstances.NewCloud(baseURL)
 
-	return &ergomakeKillCommand{baseURL, definitionsBackend, instancesBackend}
+	return &cloudKillCommand{baseURL, definitionsBackend, instancesBackend}
 }
 
-func (e *ergomakeKillCommand) Run(
+func (e *cloudKillCommand) Run(
 	ctx context.Context,
 	definitionName, instanceName string,
 	autoApprove bool,
@@ -114,7 +114,7 @@ func (e *ergomakeKillCommand) Run(
 	if err != nil {
 		s.Error()
 		sm.Stop()
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -122,7 +122,7 @@ func (e *ergomakeKillCommand) Run(
 	if err != nil {
 		s.Error()
 		sm.Stop()
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 

--- a/pkg/command/refresh/cloud.go
+++ b/pkg/command/refresh/cloud.go
@@ -19,22 +19,22 @@ import (
 	"github.com/ergomake/layerform/pkg/layerinstances"
 )
 
-type ergomakeRefreshCommand struct {
+type cloudRefreshCommand struct {
 	baseURL            string
 	instancesBackend   layerinstances.Backend
 	definitionsBackend layerdefinitions.Backend
 }
 
-var _ Refresh = &ergomakeRefreshCommand{}
+var _ Refresh = &cloudRefreshCommand{}
 
-func NewErgomake(baseURL string) *ergomakeRefreshCommand {
-	instancesBackend := layerinstances.NewErgomake(baseURL)
-	definitionsBackend := layerdefinitions.NewErgomake(baseURL)
+func NewCloud(baseURL string) *cloudRefreshCommand {
+	instancesBackend := layerinstances.NewCloud(baseURL)
+	definitionsBackend := layerdefinitions.NewCloud(baseURL)
 
-	return &ergomakeRefreshCommand{baseURL, instancesBackend, definitionsBackend}
+	return &cloudRefreshCommand{baseURL, instancesBackend, definitionsBackend}
 }
 
-func (e *ergomakeRefreshCommand) Run(
+func (e *cloudRefreshCommand) Run(
 	ctx context.Context,
 	definitionName, instanceName string,
 	vars []string,
@@ -98,7 +98,7 @@ func (e *ergomakeRefreshCommand) Run(
 	if err != nil {
 		s.Error()
 		sm.Stop()
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -106,7 +106,7 @@ func (e *ergomakeRefreshCommand) Run(
 	if err != nil {
 		s.Error()
 		sm.Stop()
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 

--- a/pkg/command/spawn/cloud.go
+++ b/pkg/command/spawn/cloud.go
@@ -18,20 +18,20 @@ import (
 	"github.com/ergomake/layerform/pkg/layerinstances"
 )
 
-type ergomakeSpawnCommand struct {
+type cloudSpawnCommand struct {
 	baseURL          string
 	instancesBackend layerinstances.Backend
 }
 
-var _ Spawn = &ergomakeSpawnCommand{}
+var _ Spawn = &cloudSpawnCommand{}
 
-func NewErgomake(baseURL string) *ergomakeSpawnCommand {
-	instancesBackend := layerinstances.NewErgomake(baseURL)
+func NewCloud(baseURL string) *cloudSpawnCommand {
+	instancesBackend := layerinstances.NewCloud(baseURL)
 
-	return &ergomakeSpawnCommand{baseURL, instancesBackend}
+	return &cloudSpawnCommand{baseURL, instancesBackend}
 }
 
-func (e *ergomakeSpawnCommand) Run(
+func (e *cloudSpawnCommand) Run(
 	ctx context.Context,
 	definitionName, instanceName string,
 	dependenciesInstance map[string]string,
@@ -62,13 +62,13 @@ func (e *ergomakeSpawnCommand) Run(
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(dataBytes))
 	if err != nil {
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 

--- a/pkg/layerdefinitions/cloud.go
+++ b/pkg/layerdefinitions/cloud.go
@@ -12,32 +12,32 @@ import (
 	"github.com/ergomake/layerform/pkg/data"
 )
 
-type ergomake struct {
+type cloud struct {
 	baseURL string
 }
 
-var _ Backend = &ergomake{}
+var _ Backend = &cloud{}
 
-func NewErgomake(baseURL string) *ergomake {
-	return &ergomake{baseURL}
+func NewCloud(baseURL string) *cloud {
+	return &cloud{baseURL}
 }
 
-func (e *ergomake) Location(ctx context.Context) (string, error) {
+func (e *cloud) Location(ctx context.Context) (string, error) {
 	return e.baseURL, nil
 }
 
-func (e *ergomake) GetLayer(ctx context.Context, name string) (*data.LayerDefinition, error) {
+func (e *cloud) GetLayer(ctx context.Context, name string) (*data.LayerDefinition, error) {
 	url := fmt.Sprintf("%s/v1/definitions/%s", e.baseURL, name)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to create http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -54,18 +54,18 @@ func (e *ergomake) GetLayer(ctx context.Context, name string) (*data.LayerDefini
 	return &layer, nil
 }
 
-func (e *ergomake) ListLayers(ctx context.Context) ([]*data.LayerDefinition, error) {
+func (e *cloud) ListLayers(ctx context.Context) ([]*data.LayerDefinition, error) {
 	url := fmt.Sprintf("%s/v1/definitions", e.baseURL)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to create http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -82,7 +82,7 @@ func (e *ergomake) ListLayers(ctx context.Context) ([]*data.LayerDefinition, err
 	return layers, nil
 }
 
-func (e *ergomake) ResolveDependencies(ctx context.Context, layer *data.LayerDefinition) ([]*data.LayerDefinition, error) {
+func (e *cloud) ResolveDependencies(ctx context.Context, layer *data.LayerDefinition) ([]*data.LayerDefinition, error) {
 	var resolvedLayers []*data.LayerDefinition
 
 	for _, dependencyName := range layer.Dependencies {
@@ -97,7 +97,7 @@ func (e *ergomake) ResolveDependencies(ctx context.Context, layer *data.LayerDef
 	return resolvedLayers, nil
 }
 
-func (e *ergomake) UpdateLayers(ctx context.Context, layers []*data.LayerDefinition) error {
+func (e *cloud) UpdateLayers(ctx context.Context, layers []*data.LayerDefinition) error {
 	dataBytes, err := json.Marshal(layers)
 	if err != nil {
 		return errors.Wrap(err, "fail to marshal layers to json")
@@ -108,13 +108,13 @@ func (e *ergomake) UpdateLayers(ctx context.Context, layers []*data.LayerDefinit
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(dataBytes))
 	if err != nil {
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 

--- a/pkg/layerinstances/cloud.go
+++ b/pkg/layerinstances/cloud.go
@@ -12,27 +12,27 @@ import (
 	"github.com/ergomake/layerform/pkg/data"
 )
 
-type ergomake struct {
+type cloud struct {
 	baseURL string
 }
 
-var _ Backend = &ergomake{}
+var _ Backend = &cloud{}
 
-func NewErgomake(baseURL string) *ergomake {
-	return &ergomake{baseURL}
+func NewCloud(baseURL string) *cloud {
+	return &cloud{baseURL}
 }
 
-func (e *ergomake) DeleteInstance(ctx context.Context, layerName string, instanceName string) error {
+func (e *cloud) DeleteInstance(ctx context.Context, layerName string, instanceName string) error {
 	url := fmt.Sprintf("%s/v1/definitions/%s/instances/%s", e.baseURL, layerName, instanceName)
 	client := &http.Client{}
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -43,17 +43,17 @@ func (e *ergomake) DeleteInstance(ctx context.Context, layerName string, instanc
 	return nil
 }
 
-func (e *ergomake) GetInstance(ctx context.Context, definitionName string, instanceName string) (*data.LayerInstance, error) {
+func (e *cloud) GetInstance(ctx context.Context, definitionName string, instanceName string) (*data.LayerInstance, error) {
 	url := fmt.Sprintf("%s/v1/definitions/%s/instances/%s", e.baseURL, definitionName, instanceName)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to create http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -75,17 +75,17 @@ func (e *ergomake) GetInstance(ctx context.Context, definitionName string, insta
 	return &instance, nil
 }
 
-func (e *ergomake) ListInstances(ctx context.Context) ([]*data.LayerInstance, error) {
+func (e *cloud) ListInstances(ctx context.Context) ([]*data.LayerInstance, error) {
 	url := fmt.Sprintf("%s/v1/instances", e.baseURL)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to create http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -102,17 +102,17 @@ func (e *ergomake) ListInstances(ctx context.Context) ([]*data.LayerInstance, er
 	return instances, nil
 }
 
-func (e *ergomake) ListInstancesByLayer(ctx context.Context, layerName string) ([]*data.LayerInstance, error) {
+func (e *cloud) ListInstancesByLayer(ctx context.Context, layerName string) ([]*data.LayerInstance, error) {
 	url := fmt.Sprintf("%s/v1/definitions/%s/instances", e.baseURL, layerName)
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to create http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return nil, errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 
@@ -129,7 +129,7 @@ func (e *ergomake) ListInstancesByLayer(ctx context.Context, layerName string) (
 	return instances, nil
 }
 
-func (e *ergomake) SaveInstance(ctx context.Context, instance *data.LayerInstance) error {
+func (e *cloud) SaveInstance(ctx context.Context, instance *data.LayerInstance) error {
 	url := fmt.Sprintf("%s/v1/instances", e.baseURL)
 	dataBytes, err := json.Marshal(instance)
 	if err != nil {
@@ -139,13 +139,13 @@ func (e *ergomake) SaveInstance(ctx context.Context, instance *data.LayerInstanc
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(dataBytes))
 	if err != nil {
-		return errors.Wrap(err, "fail to create http request to ergomake backend")
+		return errors.Wrap(err, "fail to create http request to cloud backend")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return errors.Wrap(err, "fail to perform http request to ergomake backend")
+		return errors.Wrap(err, "fail to perform http request to cloud backend")
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
This command is the first of many to come commands we'll introduce to interact with the config file without having to write it by hand. This is specially useful for using `layerform` in scripts.

Closes #77 