### PR TITLE
introduce config get-contexts command

### DIFF
--- a/cmd/cli/get_contexts.go
+++ b/cmd/cli/get_contexts.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/ergomake/layerform/internal/lfconfig"
+)
+
+func init() {
+	configCmd.AddCommand(configGetContextsCmd)
+}
+
+var configGetContextsCmd = &cobra.Command{
+	Use:   "get-contexts",
+	Short: "Display contexts from layerform config file",
+	Long:  `Display contexts from layerform config file`,
+	Run: func(_ *cobra.Command, _ []string) {
+		cfg, err := lfconfig.Load("")
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintln(os.Stdout, "No contexts configure, configure contexts using the set-context command.")
+			return
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "CURRENT\tNAME\tTYPE\tLOCATION")
+		for name, ctx := range cfg.Contexts {
+			isCurrent := name == cfg.CurrentContext
+			current := ""
+			if isCurrent {
+				current = "*"
+			}
+
+			fmt.Fprintln(w, strings.Join([]string{current, name, ctx.Type, ctx.Location()}, "\t"))
+		}
+		err = w.Flush()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to print output"))
+			os.Exit(1)
+		}
+
+	},
+	SilenceErrors: true,
+}

--- a/internal/lfconfig/config.go
+++ b/internal/lfconfig/config.go
@@ -2,6 +2,7 @@ package lfconfig
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 
@@ -29,6 +30,19 @@ type ConfigContext struct {
 	URL      string `yaml:"url,omitempty"`
 	Email    string `yaml:"email,omitempty"`
 	Password string `yaml:"password,omitempty"`
+}
+
+func (cfg *ConfigContext) Location() string {
+	switch cfg.Type {
+	case "local":
+		return fmt.Sprintf("dir://%s", cfg.Dir)
+	case "s3":
+		return fmt.Sprintf("s3://%s", cfg.Bucket)
+	case "cloud":
+		return cfg.URL
+	}
+
+	panic("unreachable")
 }
 
 func getDefaultPaths() ([]string, error) {


### PR DESCRIPTION
## Why this matters

Introduces a new command  to print in a table the existing contexts in the config file. Closes #88

## Solution

Add a command `layerform config get-contexts`

## How to test it

1. Create some contexts
```console
layerform config set-context foo -t s3 --bucket bucket --region us-east-1
layerform config set-context bar -t local --dir test
layerform config set-context baz -t local --dir test
layerform config set-context qux -t cloud --url https://qux.com \
  --email foo@bar.com --password strongpass
```

2. `layerform config get-contexts`
```console
CURRENT   NAME   TYPE    LOCATION
          bar    local   dir://test
          baz    local   dir://test
          foo    s3      s3://bucket
*         qux    cloud   https://qux.com
```
