### PR TITLE
feat: --force flag to layerform kill

### DIFF
--- a/cmd/cli/kill.go
+++ b/cmd/cli/kill.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	killCmd.Flags().StringArray("var", []string{}, "a map of variables for the layer's Terraform files. I.e. 'foo=bar,baz=qux'")
+	killCmd.Flags().Bool("force", false, "force the destruction of the layer instance even if it has dependants")
 
 	rootCmd.AddCommand(killCmd)
 }
@@ -47,6 +48,12 @@ Please notice that the kill command cannot destroy a layer instance which has de
 			os.Exit(1)
 			return
 		}
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to get --force flag, this is a bug in layerform"))
+			os.Exit(1)
+			return
+		}
 		kill, err := cfg.GetKillCommand(ctx)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, "fail to get kill command"))
@@ -56,7 +63,7 @@ Please notice that the kill command cannot destroy a layer instance which has de
 		layerName := args[0]
 		instanceName := args[1]
 
-		err = kill.Run(ctx, layerName, instanceName, false, vars)
+		err = kill.Run(ctx, layerName, instanceName, false, vars, force)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)

--- a/pkg/command/kill/cloud.go
+++ b/pkg/command/kill/cloud.go
@@ -40,6 +40,7 @@ func (e *cloudKillCommand) Run(
 	definitionName, instanceName string,
 	autoApprove bool,
 	vars []string,
+	force bool,
 ) error {
 	logger := hclog.FromContext(ctx)
 	logger.Debug("Killing instance remotely")

--- a/pkg/command/kill/cloud.go
+++ b/pkg/command/kill/cloud.go
@@ -96,7 +96,7 @@ func (e *cloudKillCommand) Run(
 	if hasDependants {
 		s.Error()
 		sm.Stop()
-		return errors.New("can't kill this layer because other layers depend on it")
+		return errors.New("can't kill this layer because other layers depend on it\nuse the --force flag to kill it anyway")
 	}
 
 	url := fmt.Sprintf("/v1/definitions/%s/instances/%s/kill", definitionName, instanceName)

--- a/pkg/command/kill/cloud.go
+++ b/pkg/command/kill/cloud.go
@@ -96,7 +96,7 @@ func (e *cloudKillCommand) Run(
 	if hasDependants {
 		s.Error()
 		sm.Stop()
-		return errors.New("can't kill this layer because other layers depend on it\nuse the --force flag to kill it anyway")
+		return errors.New("can't kill this layer because other layers depend on it")
 	}
 
 	url := fmt.Sprintf("/v1/definitions/%s/instances/%s/kill", definitionName, instanceName)

--- a/pkg/command/kill/common.go
+++ b/pkg/command/kill/common.go
@@ -10,6 +10,11 @@ import (
 	"github.com/ergomake/layerform/pkg/layerinstances"
 )
 
+type DependenceInfo struct {
+	DefinitionName string
+	InstanceName   string
+}
+
 func HasDependants(
 	ctx context.Context,
 	instancesBackend layerinstances.Backend,
@@ -48,4 +53,65 @@ func HasDependants(
 	}
 
 	return false, nil
+}
+
+func GetDependants(
+	ctx context.Context,
+	instancesBackend layerinstances.Backend,
+	definitionsBackend layerdefinitions.Backend,
+	layerName, instanceName string,
+	visited map[string]bool,
+) ([]DependenceInfo, error) {
+	hclog.FromContext(ctx).Debug("Finding dependant layers", "layer", layerName, "instance", instanceName)
+
+	definitions, err := definitionsBackend.ListLayers(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "fail to list layers")
+	}
+
+	dependantLayers := []DependenceInfo{}
+
+	visited[layerName] = true
+
+	for _, definition := range definitions {
+		isChild := false
+		for _, d := range definition.Dependencies {
+			if d == layerName {
+				isChild = true
+				break
+			}
+		}
+
+		if isChild {
+			instances, err := instancesBackend.ListInstancesByLayer(ctx, definition.Name)
+			if err != nil {
+				return nil, errors.Wrap(err, "fail to list layer instances")
+			}
+
+			for _, instance := range instances {
+				parentInstanceName := instance.GetDependencyInstanceName(layerName)
+				if parentInstanceName == instanceName {
+					dependantLayers = append(dependantLayers, DependenceInfo{
+						DefinitionName: definition.Name,
+						InstanceName:   instance.InstanceName,
+					})
+				} else if !visited[definition.Name] {
+					childDependantLayers, err := GetDependants(
+						ctx,
+						instancesBackend,
+						definitionsBackend,
+						definition.Name,
+						instance.InstanceName,
+						visited,
+					)
+					if err != nil {
+						return nil, err
+					}
+					dependantLayers = append(dependantLayers, childDependantLayers...)
+				}
+			}
+		}
+	}
+
+	return dependantLayers, nil
 }

--- a/pkg/command/kill/kill.go
+++ b/pkg/command/kill/kill.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Kill interface {
-	Run(ctx context.Context, definitionName, instanceName string, autoApprove bool, vars []string) error
+	Run(ctx context.Context, definitionName, instanceName string, autoApprove bool, vars []string, force bool) error
 }

--- a/pkg/command/kill/local.go
+++ b/pkg/command/kill/local.go
@@ -100,7 +100,10 @@ func (c *localKillCommand) Run(
 	if force {
 		autoApprove = true
 		for _, d := range dependants {
-			c.Run(ctx, d.DefinitionName, d.InstanceName, autoApprove, vars, force)
+			err = c.Run(ctx, d.DefinitionName, d.InstanceName, autoApprove, vars, force)
+			if err != nil {
+				return errors.Wrapf(err, "fail to kill dependant %s=%s", d.DefinitionName, d.InstanceName)
+			}
 		}
 	}
 

--- a/pkg/command/kill/local.go
+++ b/pkg/command/kill/local.go
@@ -77,45 +77,6 @@ func (c *localKillCommand) Run(
 		),
 	)
 
-	// hasDependants, err := HasDependants(
-	// 	ctx,
-	// 	c.instancesBackend,
-	// 	c.definitionsBackend,
-	// 	layerName,
-	// 	instanceName,
-	// )
-	// if err != nil {
-	// 	s.Error()
-	// 	sm.Stop()
-	// 	return errors.Wrap(err, "fail to check if layer has dependants")
-	// }
-
-	// if hasDependants {
-	// 	dependants, err := Dependants(
-	// 		ctx,
-	// 		c.instancesBackend,
-	// 		c.definitionsBackend,
-	// 		layerName,
-	// 		instanceName,
-	// 		make(map[string]bool),
-	// 	)
-	// 	if err != nil {
-	// 		s.Error()
-	// 		sm.Stop()
-	// 		return errors.Wrap(err, "fail to check dependants")
-	// 	}
-
-	// 	if len(dependants) > 0 {
-	// 		for _, d := range dependants {
-	// 			fmt.Print(strings.Split(d, "\n")[0])
-	// 		}
-	// 	}
-
-	// 	s.Error()
-	// 	sm.Stop()
-	// 	return errors.New("can't kill this layer because other layers depend on it")
-	// }
-
 	dependants, err := GetDependants(
 		ctx,
 		c.instancesBackend,
@@ -133,7 +94,7 @@ func (c *localKillCommand) Run(
 	if len(dependants) > 0 && !force {
 		s.Error()
 		sm.Stop()
-		return errors.New("can't kill this layer because other layers depend on it")
+		return errors.New("can't kill this layer because other layers depend on it\nuse the --force flag to kill it anyway")
 	}
 
 	if force {

--- a/pkg/command/kill/local.go
+++ b/pkg/command/kill/local.go
@@ -38,6 +38,7 @@ func (c *localKillCommand) Run(
 	layerName, instanceName string,
 	autoApprove bool,
 	vars []string,
+	force bool,
 ) error {
 	logger := hclog.FromContext(ctx)
 
@@ -129,8 +130,6 @@ func (c *localKillCommand) Run(
 		return errors.Wrap(err, "fail to check if layer has dependants")
 	}
 
-	force := true
-
 	if len(dependants) > 0 && !force {
 		s.Error()
 		sm.Stop()
@@ -138,10 +137,9 @@ func (c *localKillCommand) Run(
 	}
 
 	if force {
+		autoApprove = true
 		for _, d := range dependants {
-			fmt.Print(d.DefinitionName+" = ", d.InstanceName+"\n")
-			//c.Run(ctx, d.DefinitionName, d.InstanceName, autoApprove, vars)
-			c.Run(ctx, d.DefinitionName, d.InstanceName, autoApprove, vars)
+			c.Run(ctx, d.DefinitionName, d.InstanceName, autoApprove, vars, force)
 		}
 	}
 


### PR DESCRIPTION
## Why this matters

This PR aims to add the `--force` flag to the `layerform kill` command, adding the ability to kill multiple layers at once as opened in the issue https://github.com/ergomake/layerform/issues/60

## Solution

In addition to adding the check for the `--force` flag, a function called `GetDependants` was created, very similar to the existing function `HasDependants`, but this time returning a list of the layers to be killed in order. The verification occurs recursively, always bringing the first layers as children.

## How to test it

The best way to test would be with `examples/local` since `--force` for cloud has not yet been implemented (because I still need to test and verify that it will work correctly). To test, simply use:

```sh
$ layerform configure
$ layerform spawn foo default
$ layerform spawn bar
$ layerform spawn baz
```

So when you try to run:

```sh
$ layerform kill foo default
```

The following message will appear:

```
✗ Preparing to kill instance "default" of layer "foo"
can't kill this layer because other layers depend on it
use the --force flag to kill it anyway
exit status 1
```

To force just run:

```sh
$ layerform kill foo default --force
```

Done! The child layers will be killed first until reaching `foo=default`!

## Note to reviewers

I haven't implemented the Cloud version yet, so the `HasDependants` function still exists. I would like to check if the operation is the same (bearing in mind that the main difference is the way http requests are made).