### PR TITLE
Validate if all layers dependencies exist

### DIFF
--- a/internal/layerfile/layerfile_test.go
+++ b/internal/layerfile/layerfile_test.go
@@ -135,3 +135,49 @@ func TestToLayers_ValidateNameOfLayerDefinitions(t *testing.T) {
 		})
 	}
 }
+
+func TestToLayers_ValidateAllDependenciesExist(t *testing.T) {
+	tests := []struct {
+		name string
+		lf   layerfile
+		err  error
+	}{
+		{
+			name: "Dependencies don't exist",
+			lf: layerfile{
+				Layers: []layerfileLayer{
+					{
+						Name:         "foo",
+						Dependencies: []string{"bar"},
+					},
+				},
+			},
+			err: ErrDependencyDoesNotExist,
+		},
+		{
+			name: "Dependencies exist",
+			lf: layerfile{
+				Layers: []layerfileLayer{
+					{
+						Name:         "foo",
+						Dependencies: []string{"bar"},
+					},
+					{
+						Name: "bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.lf.ToLayers()
+			if tt.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why this matters

Resolves #75 

## Solution

Validate that all `layers[*].dependencies` exist.

## How to test it

Run `make test`.

Otherwise, we can also reproduce the issue by doing what mentioned in #75.

Here is the result in my local using a similar `layerform.json`

```
➜  layerform git:(75-validate-all-dep-exist) ✗ cat layerform.json
{
  "layers": [
    {
      "name": "foo",
      "files": ["foo.tf"]
    },
    {
      "name"  : "bar",
      "files": ["bar.tf"],
      "dependencies": ["foo", "this_layer_does_not_exist"]
    },
    {
      "name"  : "baz",
      "files": ["baz.tf"],
      "dependencies": ["foo"]
    }
  ]
}%                                                                                                                                                                                                                                                                                                                                  
```

```
➜  layerform git:(75-validate-all-dep-exist) ✗ ./layerform configure --file layerform.json
✗ Loading layer definitions from "layerform.json"
fail to load layers from layerform layers definitions file: fail to validate layers dependencies: this_layer_does_not_exist: dependency does not exist
```

## Note to reviewers

<!-- Add notes to reviewers if applicable -->