### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 <br>
 
-**After HashiCorp's announcement that they're not using the MPL license anymore, we'll be building on top of OpenTF.**
+**After HashiCorp's announcement that they're not using the MPL license anymore, we'll be building on top of [OpenTofu](https://opentofu.org/).**
 
 <br>
 


### PR DESCRIPTION


## Why this matters

Update README to reflect OpenTF name change, and adding link to new domain https://opentofu.org/

## Solution

Simple verbiage change and added hyperlink.  PS! Your template for this section of the PR description has a typo (breif, sic)
## How to test it

N/A
## Note to reviewers

See new OpenTofu site